### PR TITLE
feat: add pre build

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
+          pre-build-command: "pip install myst-parser sphinx_rtd_theme"
       - uses: actions/upload-artifact@v3
         if: github.event_name == 'pull_request'
         with:


### PR DESCRIPTION
Dans les lambdas, dans la config, on utilise ses 2 extensions, elles ont besoin d'être installé pour valider le build.