### PR TITLE
feat(publish): build destination path with project-xx repository topic

### DIFF
--- a/.github/actions/get-repo-topic/action.yaml
+++ b/.github/actions/get-repo-topic/action.yaml
@@ -1,0 +1,31 @@
+name: "Get repository specific topic"
+description: "Extract a specific topic based on provided prefix"
+
+inputs:
+  prefix:
+    description: "Prefix to match"
+    required: true
+
+outputs:
+  topic:
+    description: "Topic matched or empty string if not found"
+    value: ${{ steps.extract-topic.outputs.topic }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: extract-topic
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const getTopic = function(gh_repo, prefix) {
+            let name = '';
+            gh_repo.topics.forEach((topic) => {
+              if (topic.startsWith(prefix)) {
+                name = topic;
+              }
+            })
+            return name
+          }
+
+          core.setOutput('topic', getTopic(context.payload.repository, '${{ inputs.prefix }}'))

--- a/.github/actions/init-project-dir-documentation/action.yaml
+++ b/.github/actions/init-project-dir-documentation/action.yaml
@@ -1,0 +1,37 @@
+name: "Init Project directory documentation"
+description: "Initialize Project directory for documentation subdirectories"
+
+inputs:
+  project-name:
+    description: "Project name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Init local documentation"
+      run: |
+        mkdir docs_project_temp
+        echo '${{ inputs.project-name }}' >> docs_project_temp/index.rst
+        echo '==============' >> docs_project_temp/index.rst
+        echo '' >> docs_project_temp/index.rst
+        echo '.. toctree::' >> docs_project_temp/index.rst
+        echo '  :glob:' >> docs_project_temp/index.rst
+        echo '  :maxdepth: 2' >> docs_project_temp/index.rst
+        echo '  :caption: Repositories' >> docs_project_temp/index.rst
+        echo '' >> docs_project_temp/index.rst
+        echo '  includes/*/*' >> docs_project_temp/index.rst
+      shell: bash
+    - name: Publish project index in enginerring
+      id: push_project_index
+      uses: cpina/github-action-push-to-another-repository@main
+      with:
+        source-directory: 'docs_project_temp'
+        destination-github-username: 'meero-com'
+        destination-repository-name: 'engineering-documentation'
+        commit-message: Init ${{ inputs.project-name }} dir - See ORIGIN_COMMIT from $GITHUB_REF
+        target-branch: master
+        target-directory: docs/source/projects/${{ inputs.project-name }}/
+    - name: "Remove local documentation"
+      run:  rm -rf docs_project_temp
+      shell: bash

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -12,12 +12,59 @@ on:
   workflow_call: ~
 
 jobs:
-  publish-documentation:
+  detect-project:
     runs-on: ubuntu-latest
-
+    outputs:
+      name: ${{ steps.project-name.outputs.topic }}
+      init: ${{ steps.project-index.outputs.init }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - id: project-name
+        uses: meero-com/github-actions-shared-workflows/.github/actions/get-repo-topic@main
+        with:
+          prefix: 'project-'
+      - id: project-index
+        if: ${{ steps.project-name.outputs.topic }} != ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.API_TOKEN_GITHUB }}
+          script: |
+            github.rest.repos.getContent({
+              owner: 'meero-com',
+              repo: 'engineering-documentation',
+              path: 'docs/source/projects/${{ steps.project-name.outputs.topic }}/index.rst'
+            })
+            .then(r => core.setOutput('init', 'ok'))
+            .catch(e => core.setOutput('init', 'not-found'))
+
+
+  publish-documentation:
+    needs:
+      - detect-project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Init Project directory documentation
+      - uses: meero-com/github-actions-shared-workflows/.github/actions/init-project-dir-documentation@main
+        if: ${{ needs.detect-project.outputs.init == 'not-found' }}
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          project-name: ${{ needs.detect-project.outputs.name }}
+
+      # Sync Repo documentation to project sub-directory
+      - id: project-path
+        uses: actions/github-script@v6
+        with:
+          script: |
+            if ("${{ needs.detect-project.outputs.name }}" != '') {
+              core.setOutput('path', "${{ needs.detect-project.outputs.name }}" + '/includes/')
+            } else {
+              core.setOutput('path', '')
+            }
       - name: Publish documentation in enginerring
         id: push_directory
         uses: cpina/github-action-push-to-another-repository@main
@@ -29,4 +76,4 @@ jobs:
           destination-repository-name: 'engineering-documentation'
           commit-message: See ORIGIN_COMMIT from $GITHUB_REF
           target-branch: master
-          target-directory: docs/source/projects/${{ github.event.repository.name }}/
+          target-directory: docs/source/projects/${{ steps.project-path.outputs.path }}${{ github.event.repository.name }}/


### PR DESCRIPTION
**add a step in publish process**

This step will look for a `project-xxx` topic in the event repository
And use it in the destination path of the doc.

### Examples

**Repository with topics (project-xxx included)**
```
repo: repo_name
topics: [team-software,type-delivery,project-pod]

result path: "docs/source/projects/project-pod/repo_name/"
```

Repository with topics (bu no project-xxx)
```
repo: repo_name
topics: [team-software,type-delivery]

result path: "docs/source/projects/repo_name/"
```

No topic in repository
```
repo: repo_name
topics: []

result path: "docs/source/projects/repo_name/"
```

## Jobs/Steps
- **detect-project**
  - **project-name**: extract a topic prefixed by "project-"
  - **project-index**: check documentation repository to see if project directory is initialized
- **publish-documentation**
  - **Init project dir**: only if dir not initialized (executed only the first time)
    - _Init local documentation_: create a temp dir with index.rst inside
    - _push_project_index_: sync temp project dir to documentation repository
    - _Remove local documentation_: cleanup temp dir
  - **project-path**: build path string to include in doc synchronization
  - **push_directory**: sync repo docs dir to documentation repository (in project subdir if topic found)

# ⚠️  TODO: before merge
- [x] change references branches on (sub)actions uses