### PR TITLE
feat(action-git): add advance-tag action

### DIFF
--- a/actions/git/advance-tag/README.md
+++ b/actions/git/advance-tag/README.md
@@ -1,0 +1,27 @@
+# Git: advance-tag
+
+## Behavior
+
+Move a named tag to current commit. Recreates the tag if it's absent.
+
+## Usage
+
+```yaml
+jobs:
+  advanceTag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v2"
+
+      - name: "Move tag"
+        uses: "meero-com/github-actions-shared-workflows/actions/git/advance-tag@main"
+        with:
+          TAG_NAME: "DEV"
+          github-token: ${{ secrets.API_TOKEN_GITHUB }}
+```
+
+Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:
+
+* Use `@main` if you always want to use the latest version of the workflow.
+* Use `@<tag>` if you wan to use a specific frozen version of the workflow.

--- a/actions/git/advance-tag/action.yml
+++ b/actions/git/advance-tag/action.yml
@@ -1,0 +1,35 @@
+name: "Advance or create tag"
+description: "Advance or create tag"
+
+inputs:
+  TAG_NAME:
+    description: "Name of the tag"
+    required: true
+  github-token:
+    description: The GitHub token used to create an authenticated client
+    default: ${{ github.token }}
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Advance nightly tag
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ inputs.github-token }}          
+        script: |
+          try {
+              await github.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: "tags/${{ inputs.TAG_NAME }}"
+              })
+          } catch (e) {
+            console.log("The ${{ inputs.TAG_NAME }} tag doesn't exist yet: " + e)
+          }
+          await github.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: "refs/tags/${{ inputs.TAG_NAME }}",
+            sha: context.sha
+          })


### PR DESCRIPTION
Let's start sharing github actions like we started doing with reusable workflows.

this first one simply create or move a specific tag to current commit.

introduce some best practice:
- always place a readme next to the action
- classify action by "collection", here all git related stuff