### PR TITLE
feat(action-git): add extract-version-from-tag action

### DIFF
--- a/actions/git/extract-version-from-tag/README.md
+++ b/actions/git/extract-version-from-tag/README.md
@@ -1,0 +1,33 @@
+# Git: extract-version-from-tag
+
+## Behavior
+
+Extract version number from semver tag. 
+WARNING: Must be run on tag reference.
+
+## Usage
+
+```yaml
+jobs:
+  extract-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v3"
+
+      - name: "extract version"
+        uses: "meero-com/github-actions-shared-workflows/actions/git/extract-version-from-tag@main"
+        with:
+          PREFIX: "DEV-v"
+```
+
+Will outputs
+
+```yaml
+version_number: 1.2.3 # if ran on tag DEV-v1.2.3
+```
+
+Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:
+
+* Use `@main` if you always want to use the latest version of the workflow.
+* Use `@<tag>` if you wan to use a specific frozen version of the workflow.

--- a/actions/git/extract-version-from-tag/action.yml
+++ b/actions/git/extract-version-from-tag/action.yml
@@ -1,0 +1,29 @@
+name: "Extract version from tag"
+description: "Extract version number from semver tag. Must be run on tag reference."
+
+inputs:
+  PREFIX:
+    description: "Prefix of the tag (example 'prefix-v': 'prefix-v1.0.0' -> '1.0.0')"
+    required: false
+    default: 'v'
+
+outputs:
+  version_number:
+    description: "version number (ex: 1.0.0)"
+    value: ${{ steps.extract-version.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+      - name: "extract version from refname"
+        id: extract-version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const getVersion = function (ref_name) {
+              var rx = /${{ inputs.PREFIX }}([0-9]+\.[0-9]+\.[0-9]+)/g;
+              var arr = rx.exec(ref_name);
+              return arr[1]; 
+            }
+
+            core.setOutput('version', getVersion('${{ github.ref_name }}'))


### PR DESCRIPTION
- extract version number (semver) from tag ref

When executed on tag `PRD-v3.2.45`, it will output `3.2.45` 