### PR TITLE
fix(action-release): use branches input for newer sematic versions

### DIFF
--- a/actions/release/semantic/action.yml
+++ b/actions/release/semantic/action.yml
@@ -38,6 +38,10 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
       with:
+        branches: |
+          [
+            ${{ inputs.branch }}
+          ]
         branch: ${{ inputs.branch }}
         dry_run: false
         extends: |


### PR DESCRIPTION
by default, cycjimmy/semantic-release-action@v3 will use v19 and requires to use `branches` instead of `branch` input

https://github.com/cycjimmy/semantic-release-action#semantic_version