### PR TITLE
Fix/update nodejs 16 actions

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -27,7 +27,7 @@ jobs:
           name: "HTML Documentation"
           path: docs/build/html/
           retention-days: 3
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v6
         if: github.event_name == 'pull_request' && success()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -19,7 +19,7 @@ jobs:
       init: ${{ steps.project-index.outputs.init }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: project-name
         uses: meero-com/github-actions-shared-workflows/.github/actions/get-repo-topic@main
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Init Project directory documentation
       - uses: meero-com/github-actions-shared-workflows/.github/actions/init-project-dir-documentation@main

--- a/actions/aws/build-and-push-lambda-docker-image/README.md
+++ b/actions/aws/build-and-push-lambda-docker-image/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Move tag"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/build-and-push-lambda-docker-image@main"

--- a/actions/aws/lambda-deploy/README.md
+++ b/actions/aws/lambda-deploy/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Deploy"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/lambda-deploy@main"

--- a/actions/git/advance-tag/README.md
+++ b/actions/git/advance-tag/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Move tag"
         uses: "meero-com/github-actions-shared-workflows/actions/git/advance-tag@main"

--- a/actions/git/commit-short-sha/README.md
+++ b/actions/git/commit-short-sha/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "get commit sha"
         id: commit-short-sha


### PR DESCRIPTION
github action raise a warning at execution

`Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/github-script@v5`

action version are updated