### PR TITLE
feat(subworkflow): add post-deploy-tags workflow

### DIFF
--- a/.github/workflows/post-deploy-tags.yml
+++ b/.github/workflows/post-deploy-tags.yml
@@ -1,0 +1,44 @@
+name: _PostDeployTags (subworkflow)
+
+on:
+  workflow_call:
+    inputs:
+      source_prefix:
+        description: "Prefix for the source tag on which the worflow run (tag-ref must start with: 'v', 'DEV-v'...)"
+        type: string
+        required: true
+
+      target_prefix:
+        description: "Prefix for the destination tag to create (without the v part: 'DEV', 'PREPROD'...)"
+        type: string
+        required: true
+    
+    secrets:
+      gh_token:
+        description: "Github token with private repo access"
+        required: true
+
+
+jobs:
+  advanceTags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v3"
+
+      - name: "Extract version"
+        id: extract-version
+        uses: "meero-com/github-actions-shared-workflows/actions/git/extract-version-from-tag@main"
+        with:
+          PREFIX: ${{ inputs.source_prefix }}
+
+      - name: "Create version release tag"
+        uses: "meero-com/github-actions-shared-workflows/actions/git/advance-tag@main"
+        with:
+          TAG_NAME: "${{ inputs.target_prefix }}-v${{ steps.extract-version.outputs.version_number }}"
+          github-token: ${{ secrets.gh_token }}
+
+      - name: "Move latest tag"
+        uses: "meero-com/github-actions-shared-workflows/actions/git/advance-tag@main"
+        with:
+          TAG_NAME: "${{ inputs.target_prefix }}-latest"
+          github-token: ${{ secrets.gh_token }}

--- a/actions/git/advance-tag/action.yml
+++ b/actions/git/advance-tag/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Advance nightly tag
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}          
         script: |

--- a/subworkflows/post-deploy-tags/README.md
+++ b/subworkflows/post-deploy-tags/README.md
@@ -1,0 +1,60 @@
+# Post-deployment tags
+
+## Behavior
+
+- extract version number from current github reference (`v3.0.42`, `ANY-v3.0.42`)
+- add a new prefixed version tag (`PREF-v3.0.42`)
+- add or move the prefixed latest tag (`PREF-latest`)
+
+**WARNING** first step will fail if reference don't match rule
+
+## Usage
+
+Deploy semver tag to DEV:
+
+- from `v2.3.4` tag
+- create `DEV-v2.3.4` tag
+- create or move `DEV-latest` tag
+
+```yaml
+name: Main Workflow
+
+on:
+  push: # Update me!
+
+jobs:
+  post-deploy-tags:
+    uses: meero-com/github-actions-shared-workflows/.github/workflows/post-deploy-tags.yml@main
+    with:
+      source_prefix: 'v'
+      target_prefix: 'DEV'    
+    secrets:
+      gh_token: ${{ secrets.API_TOKEN_GITHUB }}
+```
+
+Deploy DEV-version tag to PP
+
+- from `DEV-v2.3.4` tag
+- create `PREPROD-v2.3.4` tag
+- create or move `PREPROD-latest` tag
+
+```yaml
+name: Main Workflow
+
+on:
+  push: # Update me!
+
+jobs:
+  post-deploy-tags:
+    uses: meero-com/github-actions-shared-workflows/.github/workflows/post-deploy-tags.yml@main
+    with:
+      source_prefix: 'DEV-v'
+      target_prefix: 'PREPROD'
+    secrets:
+      gh_token: ${{ secrets.API_TOKEN_GITHUB }}
+```
+
+Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:
+
+* Use `@main` if you always want to use the latest version of the workflow.
+* Use `@<tag>` if you wan to use a specific frozen version of the workflow.


### PR DESCRIPTION
subworkflow to create and move tags after a deployment (frequently used)

example:
- deploy to DEV from tag v3.2.1
- will create a tag: DEV-v3.2.1
- will move the tag: DEV-latest

The readme doc isn't well placed, but a global documentation PR will come