### PR TITLE
Feat/split promote docker

### DIFF
--- a/actions/aws/promote-docker-artifact-image/README.md
+++ b/actions/aws/promote-docker-artifact-image/README.md
@@ -1,0 +1,95 @@
+# AWS: promote-docker-artifact-image
+
+## Behavior
+
+Promote Docker artifact image
+
+- Download artifact image
+- load into Docker
+- re-tag it and push it to ECR
+- Save image as artifact and outputs artifact name and filename.
+
+## Usage
+
+```yaml
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v3"
+
+      - name: "Promote docker"
+        uses: "meero-com/github-actions-shared-workflows/actions/aws/promote-docker-artifact-image@main"
+        with:
+          version: github-commit-sha
+          artifact_name: image-uri
+          artifact_file_name: path/to/image-uri.txt
+          target_artifact_name: new-image-uri
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+```
+
+will output
+```yaml
+artifact_name: new-image-uri
+artifact_file_name: new-image-uri.txt
+```
+
+Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:
+
+* Use `@main` if you always want to use the latest version of the workflow.
+* Use `@<tag>` if you wan to use a specific frozen version of the workflow.
+
+
+## Promote example
+
+- pull image from staging environment
+- promote image to preprod environment
+
+```yaml
+jobs:
+  pull-source:
+    runs-on: ubuntu-latest
+    environment: staging
+    outputs:
+      artifact_name: ${{ steps.pull.outputs.artifact_name }}
+      artifact_filename: ${{ steps.pull.outputs.artifact_file_name }}
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v3"
+
+      - name: "Pull docker"
+        id: pull
+        uses: "meero-com/github-actions-shared-workflows/actions/aws/pull-docker-image@main"
+        with:
+          version: github-commit-sha
+          artifact_name: image-uri
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+  promote:
+    needs:
+      - pull-source
+    runs-on: ubuntu-latest
+    environment: preprod
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v3"
+
+      - name: "Promote docker"
+        uses: "meero-com/github-actions-shared-workflows/actions/aws/promote-docker-artifact-image@main"
+        with:
+          version: github-commit-sha
+          artifact_name: ${{ needs.pull-source.outputs.artifact_name }}
+          artifact_file_name: ${{ needs.pull-source.outputs.artifact_filename }}
+          target_artifact_name: new-image-uri
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+```

--- a/actions/aws/promote-docker-artifact-image/action.yml
+++ b/actions/aws/promote-docker-artifact-image/action.yml
@@ -1,0 +1,88 @@
+name: "Promote Docker artifact image"
+description: "Download artifact image, load into Docker, re-tag it and push it in ECR"
+
+inputs:
+  version:
+    description: version short sha
+    required: true
+  artifact_name:
+    description: Name of the source artifact (without extension)
+    required: true
+  artifact_file_name:
+    description: Filename of the source artifact
+    required: true
+  target_artifact_name:
+    description: Name for output artifact (without extension)
+    required: true
+  AWS_ACCESS_KEY_ID:
+    description: "Aws access key"
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: "AWS secret"
+    required: true
+  ECR_REPOSITORY:
+    description: "ECR repository"
+    required: true
+  AWS_REGION:
+    description: "AWS region"
+    required: true
+
+outputs:
+  artifact_name:
+    description: "Image artifact name"
+    value: ${{ inputs.target_artifact_name }}
+  artifact_file_name:
+    description: "Image artifact filename"
+    value: ${{ inputs.target_artifact_name }}.txt
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_file_name }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: "Load Docker image"
+      id: docker-load
+      shell: bash
+      run: |
+          docker load --input ${{ inputs.artifact_file_name }}
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ inputs.AWS_REGION }}
+
+    - name: Login to the Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Tag & Push Docker image to ECR
+      shell: bash
+      id: image-tags-uri
+      run: |
+        new_tag=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ECR_REPOSITORY }}:${{ inputs.version }}
+
+        docker tag ${{ inputs.artifact_file_name }} $new_tag
+        docker push $new_tag
+
+        echo "tag=$new_tag" >> $GITHUB_OUTPUT
+
+    - name: Save ImageURI as target_artifact_name.txt
+      env:
+        IMAGE_URI: ${{ steps.image-tags-uri.outputs.tag }}
+      run: |
+        echo $IMAGE_URI > ${{ inputs.target_artifact_name }}.txt
+      shell: bash
+
+    - name: Save Image URI as Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.target_artifact_name }}
+        path: ${{ inputs.target_artifact_name }}.txt

--- a/actions/aws/pull-docker-image/README.md
+++ b/actions/aws/pull-docker-image/README.md
@@ -1,0 +1,38 @@
+# AWS: pull-docker-image
+
+## Behavior
+
+Pull a Docker image from ECR
+Save image as artifact and outputs artifact name and filename.
+
+## Usage
+
+```yaml
+jobs:
+  pull-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Code"
+        uses: "actions/checkout@v3"
+
+      - name: "Promote docker"
+        uses: "meero-com/github-actions-shared-workflows/actions/aws/pull-docker-image@main"
+        with:
+          version: github-commit-sha
+          artifact_name: image-uri
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+```
+
+will output
+```yaml
+artifact_name: image-uri
+artifact_file_name: image-uri.txt
+```
+
+Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:
+
+* Use `@main` if you always want to use the latest version of the workflow.
+* Use `@<tag>` if you wan to use a specific frozen version of the workflow.

--- a/actions/aws/pull-docker-image/action.yml
+++ b/actions/aws/pull-docker-image/action.yml
@@ -1,0 +1,71 @@
+name: "Pull Docker image"
+description: "Pull a Docker image from ECR and store it as artifact"
+
+inputs:
+  version:
+    description: version short sha
+    required: true
+  artifact_name:
+    description: Name for artifact (without extension)
+    required: true
+  AWS_ACCESS_KEY_ID:
+    description: "Aws access key"
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: "AWS secret"
+    required: true
+  ECR_REPOSITORY:
+    description: "ECR repository"
+    required: true
+  AWS_REGION:
+    description: "AWS region"
+    required: true
+
+outputs:
+  artifact_name:
+    description: "Image artifact name"
+    value: ${{ inputs.artifact_name }}
+  artifact_file_name:
+    description: "Image artifact filename"
+    value: ${{ inputs.artifact_name }}.txt
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ inputs.AWS_REGION }}
+
+    - name: Login to the Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+    
+    - name: "Store Docker image URI"
+      id: docker-uri
+      shell: bash
+      run: |
+        echo "image-uri=$(echo ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ECR_REPOSITORY }}:${{ inputs.version }})" >> $GITHUB_OUTPUT
+
+    - name: Pull Docker image from ECR
+      shell: bash
+      run: |
+        docker pull ${{ steps.docker-uri.outputs.image-uri }}
+
+    - name: Save ImageURI as artifact_name.txt
+      env:
+        IMAGE_URI: ${{ steps.docker-uri.outputs.image-uri }}
+      run: |
+        echo $IMAGE_URI > ${{ inputs.artifact_name }}.txt
+      shell: bash
+
+    - name: Save Image URI as Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_name }}.txt


### PR DESCRIPTION
Split the docker promotion action in two steps.

- pull-docker from ECR and save it as artifact
- download artifact and promote-docker-artifact-image

The goal is to use efficiently github environment feature.

Before, the target env must contain secrets related to SOURCE_AWS and TARGET_AWS.
After, the first part (pull-docker) will use the source env (ex: staging) and the second part (promot-artifact) the target one (ex: preprod). Each of the environment should only contain secrets related to one AWS account (the target one)