### PR TITLE
fix(action-git): octokit calls with `.rest` prefix

### DIFF
--- a/actions/git/advance-tag/action.yml
+++ b/actions/git/advance-tag/action.yml
@@ -19,7 +19,7 @@ runs:
         github-token: ${{ inputs.github-token }}          
         script: |
           try {
-              await github.git.deleteRef({
+              await github.rest.git.deleteRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: "tags/${{ inputs.TAG_NAME }}"
@@ -27,7 +27,7 @@ runs:
           } catch (e) {
             console.log("The ${{ inputs.TAG_NAME }} tag doesn't exist yet: " + e)
           }
-          await github.git.createRef({
+          await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
             ref: "refs/tags/${{ inputs.TAG_NAME }}",


### PR DESCRIPTION
new version of actions/github-script (v6)
will use new version of octokit.js
so we must add `.rest` before the git calls