### PR TITLE
feat(action-release): dry-un input and version output in semantic-release

### DIFF
--- a/actions/release/semantic/README.md
+++ b/actions/release/semantic/README.md
@@ -2,7 +2,7 @@
 
 ## Behavior
 
-Apply semantic relase n specified commit.
+Apply semantic relase on specified commit.
 
 ## Usage
 
@@ -17,10 +17,23 @@ jobs:
           persist-credentials: false
 
       - name: "Semantic release"
+        id: release
         uses: "meero-com/github-actions-shared-workflows/actions/release/semantic@main"
         with:
           github-token: ${{ secrets.API_TOKEN_GITHUB }}
           npm-token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Do something when a new release published
+        if: steps.release.outputs.new_release_published == 'true'
+        run: |
+          echo ${{ steps.release.outputs.new_release_version }}
+```
+
+
+will output
+```yaml
+new_release_published: "true"
+new_release_version: v1.2.3
 ```
 
 Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:

--- a/actions/release/semantic/action.yml
+++ b/actions/release/semantic/action.yml
@@ -1,5 +1,5 @@
-name: "Advance or create tag"
-description: "Advance or create tag"
+name: "Semantic release"
+description: "Semantic release"
 
 inputs:
   github-token:
@@ -12,6 +12,18 @@ inputs:
     description: The branch on which releases should happen
     default: "main"
     required: false
+  dry-run:
+    description: Whether to run semantic release in dry-run mode
+    default: false
+    required: false
+
+outputs:
+  new_release_published:
+    description: "Whether a new release was published ('true' or 'false')"
+    value: ${{ steps.semantic-release.outputs.new_release_published }}
+  new_release_version:
+    description: "Version of the new release"
+    value: ${{ steps.semantic-release.outputs.new_release_version }}
 
 runs:
   using: "composite"
@@ -33,6 +45,7 @@ runs:
       shell: bash
 
     - name: Semantic Release
+      id: semantic-release
       uses: cycjimmy/semantic-release-action@v3
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
@@ -41,7 +54,7 @@ runs:
         branches: |
           ["${{ inputs.branch }}"]
         branch: 'oldconf'
-        dry_run: false
+        dry_run: ${{ inputs.dry-run }}
         extends: |
           @meero/github-actions-shared-workflows
         extra_plugins: |


### PR DESCRIPTION
- add `dry-run` input
- add outputs `new_release_published` and `new_release_version`