### PR TITLE
fix(action-aws): docker promotion with cache instead of artifact

### DIFF
--- a/actions/aws/promote-docker-artifact-image/README.md
+++ b/actions/aws/promote-docker-artifact-image/README.md
@@ -2,12 +2,13 @@
 
 ## Behavior
 
-Promote Docker artifact image
+Promote Docker artifact/cached image
 
-- Download artifact image
+- Restore cached image
 - load into Docker
 - re-tag it and push it to ECR
-- Save image as artifact and outputs artifact name and filename.
+- Save image_uri (docker tag) as artifact
+- outputs artifact name and filename.
 
 ## Usage
 

--- a/actions/aws/promote-docker-artifact-image/action.yml
+++ b/actions/aws/promote-docker-artifact-image/action.yml
@@ -41,11 +41,12 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/cache/restore@v3
       id: dl-artifact
       with:
-        name: ${{ inputs.artifact_name }}
-        path: path/to/artifact
+        key: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_file_name }}
+        fail-on-cache-miss: true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -54,7 +55,7 @@ runs:
       id: docker-load
       shell: bash
       run: |
-          docker_image_name=${{steps.dl-artifact.outputs.download-path}}/${{ inputs.artifact_file_name }}
+          docker_image_name=${{ inputs.artifact_file_name }}
 
           docker load --input $docker_image_name
 

--- a/actions/aws/pull-docker-image/README.md
+++ b/actions/aws/pull-docker-image/README.md
@@ -3,7 +3,7 @@
 ## Behavior
 
 Pull a Docker image from ECR
-Save image as artifact and outputs artifact name and filename.
+Save image in cache and outputs cache key and path.
 
 ## Usage
 
@@ -28,8 +28,8 @@ jobs:
 
 will output
 ```yaml
-artifact_name: image-uri
-artifact_file_name: image-uri.txt
+artifact_name: image-uri-345678-6
+artifact_file_name: /tmp/docker/image-uri.txt
 ```
 
 Beware of using a `@ref` (`@main` in the example above) which suits your stability requirements in your workflow:

--- a/actions/aws/pull-docker-image/action.yml
+++ b/actions/aws/pull-docker-image/action.yml
@@ -20,14 +20,18 @@ inputs:
   AWS_REGION:
     description: "AWS region"
     required: true
+  docker_folder:
+    description: "temp folder to store docker images"
+    required: false
+    default: "/tmp/docker"
 
 outputs:
   artifact_name:
     description: "Image artifact name"
-    value: ${{ inputs.artifact_name }}
+    value: ${{ steps.artifact-keys.outputs.key }}
   artifact_file_name:
     description: "Image artifact filename"
-    value: ${{ inputs.artifact_name }}.tar.gz
+    value: ${{ steps.artifact-keys.outputs.path }}
   image_tag:
     description: "Image tag"
     value: ${{ steps.pull-docker.outputs.tag }}
@@ -35,6 +39,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - id: artifact-keys
+      shell: bash
+      run: |
+        echo "key=$(echo ${{ inputs.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }})" >> $GITHUB_OUTPUT
+        echo "path=$(echo ${{ inputs.docker_folder }}/${{ inputs.artifact_name }}.tar.gz)" >> $GITHUB_OUTPUT
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -68,11 +78,11 @@ runs:
     - name: Save Docker image as TAR
       shell: bash
       run: |
-        mkdir -p /tmp/docker
-        docker save ${{ steps.pull-docker.outputs.tag }} | gzip > /tmp/docker/${{ inputs.artifact_name }}.tar.gz
+        mkdir -p ${{ inputs.docker_folder }}
+        docker save ${{ steps.pull-docker.outputs.tag }} | gzip > ${{ steps.artifact-keys.outputs.path }}
 
-    - name: Save Image URI as Artifact
-      uses: actions/upload-artifact@v3
+    - name: Save Docker image in Cache
+      uses: actions/cache/save@v3
       with:
-        name: ${{ inputs.artifact_name }}
-        path: /tmp/docker/${{ inputs.artifact_name }}.tar.gz
+        key: ${{ steps.artifact-keys.outputs.key }}
+        path: ${{ steps.artifact-keys.outputs.path }}


### PR DESCRIPTION
Use cache instead of artifact to share docker images during promotion in GHA workflows

https://www.notion.so/meero-com/Reduce-lambda-container-promotion-time-in-GHA-3714d85db8254c60b1fe3a45f4bcddd1