### PR TITLE
feat(lambda-deploy): add or update dd env vars

### DIFF
--- a/actions/aws/lambda-deploy/action.yml
+++ b/actions/aws/lambda-deploy/action.yml
@@ -59,6 +59,16 @@ runs:
         echo "lambda_version=$version" >> $GITHUB_OUTPUT
         echo "Deployed version ${version} of the lambda $LAMBDA_FUNCTION_NAME"
 
+    - name: Add or update Datadog environment variables
+      shell: bash
+      run: |
+        EXTRACT_VERSION=$(echo $IMAGE_URI | sed "s|.*:||g")
+        UPDATED_ENVIRONMENT_VARIABLES=$(aws lambda get-function-configuration --function-name ${LAMBDA_FUNCTION_NAME} | \
+          jq --compact-output ".Environment + {\"Variables\": (.Environment.Variables + {\"DD_VERSION\": env.EXTRACT_VERSION, \"DD_GIT_COMMIT_SHA\": env.GITHUB_SHA })}")
+
+        aws lambda update-function-configuration --function-name ${LAMBDA_FUNCTION_NAME} \
+          --environment ${UPDATED_ENVIRONMENT_VARIABLES}
+
     - name: Update the Lambda Alias
       id: update_function_alias
       if: ${{ inputs.LAMBDA_FUNCTION_ALIAS != '' }}

--- a/actions/aws/lambda-deploy/action.yml
+++ b/actions/aws/lambda-deploy/action.yml
@@ -60,7 +60,11 @@ runs:
         echo "Deployed version ${version} of the lambda $LAMBDA_FUNCTION_NAME"
 
     - name: Add or update Datadog environment variables
+      id: datadog-env-vars
       shell: bash
+      env:
+        IMAGE_URI: ${{ steps.vars.outputs.image }}
+        LAMBDA_FUNCTION_NAME: ${{ inputs.LAMBDA_FUNCTION_NAME }}
       run: |
         EXTRACT_VERSION=$(echo $IMAGE_URI | sed "s|.*:||g")
         UPDATED_ENVIRONMENT_VARIABLES=$(aws lambda get-function-configuration --function-name ${LAMBDA_FUNCTION_NAME} | \

--- a/actions/aws/lambda-deploy/action.yml
+++ b/actions/aws/lambda-deploy/action.yml
@@ -66,9 +66,9 @@ runs:
         IMAGE_URI: ${{ steps.vars.outputs.image }}
         LAMBDA_FUNCTION_NAME: ${{ inputs.LAMBDA_FUNCTION_NAME }}
       run: |
-        EXTRACT_VERSION=$(echo $IMAGE_URI | sed "s|.*:||g")
+        export EXTRACTED_VERSION=$(echo $IMAGE_URI | sed "s|.*:||g")
         UPDATED_ENVIRONMENT_VARIABLES=$(aws lambda get-function-configuration --function-name ${LAMBDA_FUNCTION_NAME} | \
-          jq --compact-output ".Environment + {\"Variables\": (.Environment.Variables + {\"DD_VERSION\": env.EXTRACT_VERSION, \"DD_GIT_COMMIT_SHA\": env.GITHUB_SHA })}")
+          jq --compact-output ".Environment + {\"Variables\": (.Environment.Variables + {\"DD_VERSION\": env.EXTRACTED_VERSION, \"DD_GIT_COMMIT_SHA\": env.GITHUB_SHA })}")
 
         aws lambda update-function-configuration --function-name ${LAMBDA_FUNCTION_NAME} \
           --environment ${UPDATED_ENVIRONMENT_VARIABLES}


### PR DESCRIPTION
In order to meet the Datadog requirements to track the deployment history in Datadog and enable source code integration, we need to deploy and update DD_VERSION & DD_GIT_COMMIT_SHA environment variables.