### PR TITLE
Fix/update actions

### DIFF
--- a/.github/actions/get-repo-topic/action.yaml
+++ b/.github/actions/get-repo-topic/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - id: extract-topic
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const getTopic = function(gh_repo, prefix) {

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -44,7 +44,7 @@ jobs:
       released_version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run pre-commit rules
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
   workflow-validation:
     name: Github Action Workflows validation

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -27,7 +27,7 @@ jobs:
           name: "HTML Documentation"
           path: docs/build/html/
           retention-days: 3
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: github.event_name == 'pull_request' && success()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"

--- a/.github/workflows/post-deploy-tags.yml
+++ b/.github/workflows/post-deploy-tags.yml
@@ -23,7 +23,7 @@ jobs:
   advanceTags:
     runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
 
       - name: "Extract version"
         id: extract-version

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -19,7 +19,7 @@ jobs:
       init: ${{ steps.project-index.outputs.init }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: project-name
         uses: meero-com/github-actions-shared-workflows/.github/actions/get-repo-topic@main
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Init Project directory documentation
       - uses: meero-com/github-actions-shared-workflows/.github/actions/init-project-dir-documentation@main

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -26,7 +26,7 @@ jobs:
           prefix: 'project-'
       - id: project-index
         if: ${{ steps.project-name.outputs.topic != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.API_TOKEN_GITHUB }}
           script: |
@@ -57,7 +57,7 @@ jobs:
 
       # Sync Repo documentation to project sub-directory
       - id: project-path
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             if ("${{ needs.detect-project.outputs.name }}" != '') {

--- a/actions/aws/build-and-push-docker-image/README.md
+++ b/actions/aws/build-and-push-docker-image/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Build and Push docker container to ECR"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/build-and-push-docker-image@main"

--- a/actions/aws/build-and-push-docker-image/action.yml
+++ b/actions/aws/build-and-push-docker-image/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: "Build image Tags/URIs"
       id: image-tags-uri

--- a/actions/aws/build-and-push-docker-image/action.yml
+++ b/actions/aws/build-and-push-docker-image/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         version: v0.9.1
 

--- a/actions/aws/build-and-push-docker-image/action.yml
+++ b/actions/aws/build-and-push-docker-image/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         push: true
         file: ${{ inputs.dockerfile }}

--- a/actions/aws/build-and-push-docker-image/action.yml
+++ b/actions/aws/build-and-push-docker-image/action.yml
@@ -41,7 +41,7 @@ runs:
         version: v0.9.1
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/build-and-push-lambda-docker-image/README.md
+++ b/actions/aws/build-and-push-lambda-docker-image/README.md
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "build-lambda-container"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/build-and-push-lambda-docker-image@main"

--- a/actions/aws/build-and-push-lambda-docker-image/action.yml
+++ b/actions/aws/build-and-push-lambda-docker-image/action.yml
@@ -37,7 +37,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         version: v0.9.1
 

--- a/actions/aws/build-and-push-lambda-docker-image/action.yml
+++ b/actions/aws/build-and-push-lambda-docker-image/action.yml
@@ -42,7 +42,7 @@ runs:
         version: v0.9.1
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/build-and-push-lambda-docker-image/action.yml
+++ b/actions/aws/build-and-push-lambda-docker-image/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         push: true
         file: ${{ inputs.dockerfile }}

--- a/actions/aws/build-and-push-lambda-docker-image/action.yml
+++ b/actions/aws/build-and-push-lambda-docker-image/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: "Build image Tags/URIs"
       id: image-tags-uri

--- a/actions/aws/ecr-public-login/README.md
+++ b/actions/aws/ecr-public-login/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "ECR public login"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/ecr-public-login@main"

--- a/actions/aws/ecr-public-login/action.yml
+++ b/actions/aws/ecr-public-login/action.yml
@@ -24,6 +24,6 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
       with:
         registry-type: public

--- a/actions/aws/ecr-public-login/action.yml
+++ b/actions/aws/ecr-public-login/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/ecs-onejob-task/README.md
+++ b/actions/aws/ecs-onejob-task/README.md
@@ -14,7 +14,7 @@ jobs:
     name: "Run onejob DB migrations"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: "meero-com/github-actions-shared-workflows/actions/aws/rds-run-migrations@main"
         with:

--- a/actions/aws/ecs-onejob-task/action.yml
+++ b/actions/aws/ecs-onejob-task/action.yml
@@ -54,7 +54,7 @@ runs:
       run: echo "image=$(cat ${{ inputs.artifact_filename }})" >> $GITHUB_OUTPUT
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/lambda-deploy/README.md
+++ b/actions/aws/lambda-deploy/README.md
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Deploy"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/lambda-deploy@main"

--- a/actions/aws/lambda-deploy/action.yml
+++ b/actions/aws/lambda-deploy/action.yml
@@ -39,7 +39,7 @@ runs:
       run: echo "image=$(cat ${{ inputs.artifact_filename }})" >> $GITHUB_OUTPUT
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/promote-docker-artifact-image/README.md
+++ b/actions/aws/promote-docker-artifact-image/README.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Promote docker"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/promote-docker-artifact-image@main"
@@ -60,7 +60,7 @@ jobs:
       artifact_filename: ${{ steps.pull.outputs.artifact_file_name }}
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Pull docker"
         id: pull
@@ -80,7 +80,7 @@ jobs:
     environment: preprod
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Promote docker"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/promote-docker-artifact-image@main"

--- a/actions/aws/promote-docker-artifact-image/action.yml
+++ b/actions/aws/promote-docker-artifact-image/action.yml
@@ -41,7 +41,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       id: dl-artifact
       with:
         key: ${{ inputs.artifact_name }}

--- a/actions/aws/promote-docker-artifact-image/action.yml
+++ b/actions/aws/promote-docker-artifact-image/action.yml
@@ -62,7 +62,7 @@ runs:
           echo "docker_image_name=$docker_image_name" >> $GITHUB_OUTPUT
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/promote-docker-artifact-image/action.yml
+++ b/actions/aws/promote-docker-artifact-image/action.yml
@@ -49,7 +49,7 @@ runs:
         fail-on-cache-miss: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: "Load Docker image"
       id: docker-load

--- a/actions/aws/promote-docker-artifact-image/action.yml
+++ b/actions/aws/promote-docker-artifact-image/action.yml
@@ -70,7 +70,7 @@ runs:
 
     - name: Login to the Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Tag & Push Docker image to ECR
       shell: bash

--- a/actions/aws/promote-docker-image/README.md
+++ b/actions/aws/promote-docker-image/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Promote docker"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/promote-docker-image@main"

--- a/actions/aws/promote-docker-image/action.yml
+++ b/actions/aws/promote-docker-image/action.yml
@@ -42,7 +42,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Configure AWS Credentials - Source account
       uses: aws-actions/configure-aws-credentials@v4

--- a/actions/aws/promote-docker-image/action.yml
+++ b/actions/aws/promote-docker-image/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Login to the Amazon ECR - Source account
       id: login-ecr-source
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
     
     - name: "Store Docker image URI from source account"
       id: docker-uri-source
@@ -75,7 +75,7 @@ runs:
 
     - name: Login to the Amazon ECR - Target account
       id: login-ecr-target
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Tag & Push Docker image to target ECR
       shell: bash

--- a/actions/aws/promote-docker-image/action.yml
+++ b/actions/aws/promote-docker-image/action.yml
@@ -45,7 +45,7 @@ runs:
       uses: docker/setup-buildx-action@v2
 
     - name: Configure AWS Credentials - Source account
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.SOURCE_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.SOURCE_AWS_SECRET_ACCESS_KEY }}
@@ -67,7 +67,7 @@ runs:
         docker pull ${{ steps.docker-uri-source.outputs.image-uri }}
 
     - name: Configure AWS Credentials - Target account
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.TARGET_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.TARGET_AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/pull-docker-image/README.md
+++ b/actions/aws/pull-docker-image/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Promote docker"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/pull-docker-image@main"

--- a/actions/aws/pull-docker-image/action.yml
+++ b/actions/aws/pull-docker-image/action.yml
@@ -82,7 +82,7 @@ runs:
         docker save ${{ steps.pull-docker.outputs.tag }} | gzip > ${{ steps.artifact-keys.outputs.path }}
 
     - name: Save Docker image in Cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         key: ${{ steps.artifact-keys.outputs.key }}
         path: ${{ steps.artifact-keys.outputs.path }}

--- a/actions/aws/pull-docker-image/action.yml
+++ b/actions/aws/pull-docker-image/action.yml
@@ -57,7 +57,7 @@ runs:
 
     - name: Login to the Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
     
     - name: "Store Docker image URI"
       id: docker-uri

--- a/actions/aws/pull-docker-image/action.yml
+++ b/actions/aws/pull-docker-image/action.yml
@@ -49,7 +49,7 @@ runs:
       uses: docker/setup-buildx-action@v2
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/pull-docker-image/action.yml
+++ b/actions/aws/pull-docker-image/action.yml
@@ -46,7 +46,7 @@ runs:
         echo "path=$(echo ${{ inputs.docker_folder }}/${{ inputs.artifact_name }}.tar.gz)" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/actions/aws/s3-upload-artifact/README.md
+++ b/actions/aws/s3-upload-artifact/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Upload OpenAPI file to S3"
         uses: "meero-com/github-actions-shared-workflows/actions/aws/s3-upload-artifact@main"

--- a/actions/aws/s3-upload-artifact/action.yml
+++ b/actions/aws/s3-upload-artifact/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/aws/update-and-deploy-rest-api/README.md
+++ b/actions/aws/update-and-deploy-rest-api/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Update & Deploy Rest API"
         id: deploy_rest_apigw

--- a/actions/aws/update-and-deploy-rest-api/action.yml
+++ b/actions/aws/update-and-deploy-rest-api/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}

--- a/actions/git/advance-tag/README.md
+++ b/actions/git/advance-tag/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Move tag"
         uses: "meero-com/github-actions-shared-workflows/actions/git/advance-tag@main"

--- a/actions/git/advance-tag/action.yml
+++ b/actions/git/advance-tag/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Advance nightly tag
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github-token }}          
         script: |

--- a/actions/git/commit-short-sha/README.md
+++ b/actions/git/commit-short-sha/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "get commit sha"
         id: commit-short-sha

--- a/actions/git/extract-version-from-tag/README.md
+++ b/actions/git/extract-version-from-tag/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "extract version"
         uses: "meero-com/github-actions-shared-workflows/actions/git/extract-version-from-tag@main"

--- a/actions/git/extract-version-from-tag/action.yml
+++ b/actions/git/extract-version-from-tag/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
       - name: "extract version from refname"
         id: extract-version
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const getVersion = function (ref_name) {

--- a/actions/git/git-auth-global/README.md
+++ b/actions/git/git-auth-global/README.md
@@ -16,7 +16,7 @@ jobs:
   advanceTag:
     runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
 
       - name: "Git Auth Global"
         uses: "meero-com/github-actions-shared-workflows/actions/git/git-auth-global@main"

--- a/actions/precommit/bom-compliance/README.md
+++ b/actions/precommit/bom-compliance/README.md
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: BOM compliance
         uses: "meero-com/github-actions-shared-workflows/actions/precommit/bom-compliance@main"
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: BOM compliance
         uses: ./.github/action/bom-compliance

--- a/actions/precommit/bom-compliance/action.yml
+++ b/actions/precommit/bom-compliance/action.yml
@@ -38,9 +38,9 @@ runs:
         github-token: ${{ inputs.gh_token }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Build version name
       id: override-version-name

--- a/actions/precommit/bom-compliance/action.yml
+++ b/actions/precommit/bom-compliance/action.yml
@@ -70,7 +70,7 @@ runs:
       shell: bash
 
     - name: BOM compliance
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
       with:
         extra_args: ${{ inputs.hook_name }} --hook-stage manual
       env:

--- a/actions/precommit/render-openapi-template/README.md
+++ b/actions/precommit/render-openapi-template/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Render OpenAPI ApiGateway file"
         uses: "meero-com/github-actions-shared-workflows/actions/precommit/render-openapi-template@main"

--- a/actions/precommit/render-openapi-template/action.yml
+++ b/actions/precommit/render-openapi-template/action.yml
@@ -39,7 +39,7 @@ runs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Generate openapi file
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
       with:
         extra_args: ${{ inputs.hook_render }} --hook-stage manual
 
@@ -49,7 +49,7 @@ runs:
       shell: bash
 
     - name: Validate openapi file
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
       with:
         extra_args: ${{ inputs.hook_validate }} --hook-stage manual
 

--- a/actions/precommit/render-openapi-template/action.yml
+++ b/actions/precommit/render-openapi-template/action.yml
@@ -32,9 +32,9 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       env:
-        PYTHON_VERSION: '3.10'
+        PYTHON_VERSION: '3.12'
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 

--- a/actions/release/publish-apidoc/README.md
+++ b/actions/release/publish-apidoc/README.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Upload OpenAPI file to ApiDoc"
         uses: "meero-com/github-actions-shared-workflows/actions/release/publish-apidoc@main"

--- a/actions/release/semantic/README.md
+++ b/actions/release/semantic/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           persist-credentials: false
 
@@ -32,11 +32,11 @@ Beware of using a `@ref` (`@main` in the example above) which suits your stabili
 
 To operate on protected branches you must pass a github Personal Access Token as github-token.
 AND
-Avoid persisting credentials as part of actions/checkout@v3 by setting the parameter persist-credentials: false.
+Avoid persisting credentials as part of actions/checkout@v4 by setting the parameter persist-credentials: false.
 
 ```yaml
       - name: "Checkout Code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           persist-credentials: false
 ```

--- a/actions/release/semantic/action.yml
+++ b/actions/release/semantic/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Semantic Release
       id: semantic-release
-      uses: cycjimmy/semantic-release-action@v3
+      uses: cycjimmy/semantic-release-action@v4
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NPM_TOKEN: ${{ inputs.npm-token }}

--- a/actions/release/semantic/action.yml
+++ b/actions/release/semantic/action.yml
@@ -24,9 +24,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: '16.x'
+        node-version: '20.x'
 
     - name: "Add package.json if missing"
       run: |


### PR DESCRIPTION
update versions:
- node to 20.x
- python to 3.12

update actions:
- actions/cache to v4
- actions/checkout to v4
- actions/github-script to v7
- actions/setup-node to v4 and node to 20.x
- actions/setup-python to v5 and python to 3.12
- aws-actions/amazon-ecr-login to v2
- aws-actions/configure-aws-credentials to v4
- cycjimmy/semantic-release-action to v4
- docker/build-push-action to v5
- docker/setup-buildx-action to v3
- pre-commit/action to v3.0.1